### PR TITLE
Added check to avoid 404 error before viewer initialization

### DIFF
--- a/dist/quagga.js
+++ b/dist/quagga.js
@@ -1409,7 +1409,7 @@ define('input_stream',["image_loader"], function(ImageLoader) {
 
         that.setInputStream = function(config) {
             _config = config;
-            video.src = config.src;
+            video.src = (typeof config.src !== 'undefined') ? config.src : '';
         };
 
         that.ended = function() {

--- a/src/input_stream.js
+++ b/src/input_stream.js
@@ -29,7 +29,7 @@ define(["image_loader"], function(ImageLoader) {
 
         that.setInputStream = function(config) {
             _config = config;
-            video.src = config.src;
+            video.src = (typeof config.src !== 'undefined') ? config.src : '';
         };
 
         that.ended = function() {


### PR DESCRIPTION
Adds a check to avoid a 404 error, which happened if the user didn't automatically accept webcam access.

Before this, the `src` attribute of the `video` tag was set to `undefined`, which led to a 404 error on the URL `http://domain.tld/path_with_scanner/undefined`. It is now just set to an empty string, which solves the problem.