### PR TITLE
Allow multiple barcodes to be decoded

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,6 @@
     "ecmaFeatures": {
         "blockBindings": true,
         "forOf": true,
-        "blockBindings": true,
         "defaultParams": true,
         "globalReturn": false,
         "modules": true,
@@ -59,7 +58,6 @@
         "comma-style": [2, "last"],
         "consistent-this": [1, "self"],
         "eol-last": 0,
-        "new-cap": 0,
         "new-parens": 2,
         "no-array-constructor": 2,
         "no-mixed-spaces-and-tabs": 2,

--- a/README.md
+++ b/README.md
@@ -357,7 +357,8 @@ options within the `decoder` are for debugging/visualization purposes only.
   showPattern: false,
   readers: [
     'code_128_reader'
-  ]
+  ],
+  multiple: false
 }
 ```
 
@@ -379,6 +380,10 @@ explicitly define the set of barcodes for their use-case. More decoders means
 more possible clashes, or false-positives. One should take care of the order
 the readers are given, since some might return a value even though it is not
 the correct type (EAN-13 vs. UPC-A).
+
+The `multiple` property tells the decoder if it should stop after finding a single result.  If multiple is set to
+`true`, the `result` object will have a `barcodes` array, each of which is a `result` object with it's own `codeResult`,
+`box`, `line`, etc.
 
 The remaining properties `drawBoundingBox`, `showFrequency`, `drawScanline` and
 `showPattern` are mostly of interest during debugging and visualization.

--- a/README.md
+++ b/README.md
@@ -381,8 +381,9 @@ more possible clashes, or false-positives. One should take care of the order
 the readers are given, since some might return a value even though it is not
 the correct type (EAN-13 vs. UPC-A).
 
-The `multiple` property tells the decoder if it should stop after finding a single result.  If multiple is set to
-`true`, the `result` object will have a `barcodes` array, each of which is a `result` object with it's own `codeResult`,
+The `multiple` property tells the decoder if it should stop after finding a 
+single result.  If multiple is set to `true`, the `result` object will have a
+`barcodes` array, each of which is a `result` object with it's own `codeResult`,
 `box`, `line`, etc.
 
 The remaining properties `drawBoundingBox`, `showFrequency`, `drawScanline` and

--- a/README.md
+++ b/README.md
@@ -381,10 +381,11 @@ more possible clashes, or false-positives. One should take care of the order
 the readers are given, since some might return a value even though it is not
 the correct type (EAN-13 vs. UPC-A).
 
-The `multiple` property tells the decoder if it should stop after finding a 
-single result.  If multiple is set to `true`, the `result` object will have a
-`barcodes` array, each of which is a `result` object with it's own `codeResult`,
-`box`, `line`, etc.
+The `multiple` property tells the decoder if it should continue decoding after
+finding a valid barcode.  If multiple is set to `true`, the results will be 
+returned as an array of result objects.  Each object in the array will have a
+`box`, and may have a `codeResult` depending on the success of decoding the 
+individual box.
 
 The remaining properties `drawBoundingBox`, `showFrequency`, `drawScanline` and
 `showPattern` are mostly of interest during debugging and visualization.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-loader": "^5.3.2",
     "chai": "^3.4.1",
     "core-js": "^1.2.1",
+    "eslint": "^1.10.3",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-nodeunit": "^0.4.1",
@@ -39,7 +40,8 @@
     "test": "grunt test",
     "integrationtest": "grunt integrationtest",
     "build": "webpack && webpack --config webpack.config.min.js && grunt uglyasm && webpack --config webpack.node.config.js",
-    "watch": "webpack --watch"
+    "watch": "webpack --watch",
+    "lint": "eslint src"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chai": "^3.4.1",
     "core-js": "^1.2.1",
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-karma": "^0.12.1",
     "isparta-loader": "^1.0.0",
@@ -21,9 +22,8 @@
     "karma-coverage": "^0.5.2",
     "karma-mocha": "~0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
-    "karma-sinon-chai": "^1.1.0",
     "karma-sinon": "^1.0.4",
-    "karma-sinon-chai": "~0.2.0",
+    "karma-sinon-chai": "^1.1.0",
     "karma-source-map-support": "^1.1.0",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.2",
@@ -63,7 +63,7 @@
   ],
   "author": "Christoph Oberhofer <ch.oberhofer@gmail.com>",
   "license": "MIT",
-  "engines":{
+  "engines": {
     "node": ">= 4.0"
   },
   "dependencies": {

--- a/src/barcode_decoder.js
+++ b/src/barcode_decoder.js
@@ -267,21 +267,23 @@ export default {
                 return decodeFromBoundingBox(box);
             },
             decodeFromBoundingBoxes: function(boxes) {
-                var i, result, barcodes = [];
+                var i, result,
+                    barcodes = [],
+                    multiple = config.multiple;
+
                 for ( i = 0; i < boxes.length; i++) {
-                    result = decodeFromBoundingBox(boxes[i]);
-                    if (result && result.codeResult) {
-                        result.box = boxes[i];
+                    const box = boxes[i];
+                    result = decodeFromBoundingBox(box) || {};
+                    result.box = box;
 
-                        if (!config.multiple) {
-                            return result;
-                        }
-
+                    if (multiple) {
                         barcodes.push(result);
+                    } else if (result.codeResult) {
+                        return result;
                     }
                 }
 
-                if (config.multiple) {
+                if (multiple) {
                     return {
                         barcodes
                     };

--- a/src/barcode_decoder.js
+++ b/src/barcode_decoder.js
@@ -267,13 +267,24 @@ export default {
                 return decodeFromBoundingBox(box);
             },
             decodeFromBoundingBoxes: function(boxes) {
-                var i, result;
+                var i, result, barcodes = [];
                 for ( i = 0; i < boxes.length; i++) {
                     result = decodeFromBoundingBox(boxes[i]);
                     if (result && result.codeResult) {
                         result.box = boxes[i];
-                        return result;
+
+                        if (!config.multiple) {
+                            return result;
+                        }
+
+                        barcodes.push(result);
                     }
+                }
+
+                if (config.multiple) {
+                    return {
+                        barcodes
+                    };
                 }
             },
             setReaders: function(readers) {

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -168,10 +168,16 @@ function transformResult(result) {
         return;
     }
 
+    if (result.barcodes) {
+        for (i = 0; i < result.barcodes.length; i++) {
+            transformResult(result.barcodes[i]);
+        }
+    }
 
     if (result.line && result.line.length === 2) {
         moveLine(result.line);
     }
+
     if (result.boxes && result.boxes.length > 0) {
         for (i = 0; i < result.boxes.length; i++) {
             moveBox(result.boxes[i]);
@@ -195,14 +201,29 @@ function transformResult(result) {
     }
 }
 
+function addResult (result, imageData) {
+    var i;
+
+    if (!imageData || !result || !_resultCollector) {
+        return;
+    }
+
+    if (result.barcodes) {
+        for (i = 0; i < result.barcodes.length; i++) {
+            addResult(result.barcodes[i], imageData);
+        }
+        return;
+    }
+
+    if (result.codeResult) {
+        _resultCollector.addResult(imageData, _inputStream.getCanvasSize(), result.codeResult);
+    }
+}
+
 function publishResult(result, imageData) {
     if (_onUIThread) {
         transformResult(result);
-        if (imageData && result && result.codeResult) {
-            if (_resultCollector) {
-                _resultCollector.addResult(imageData, _inputStream.getCanvasSize(), result.codeResult);
-            }
-        }
+        addResult(result, imageData);
     }
 
     Events.publish("processed", result);

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -220,6 +220,12 @@ function addResult (result, imageData) {
     }
 }
 
+function hasCodeResult (result) {
+    return result && result.barcodes ?
+      result.barcodes.some(barcode => barcode.codeResult) :
+      result.codeResult;
+}
+
 function publishResult(result, imageData) {
     if (result && _onUIThread) {
         transformResult(result);
@@ -227,7 +233,7 @@ function publishResult(result, imageData) {
     }
 
     Events.publish("processed", result);
-    if (result && result.codeResult) {
+    if (hasCodeResult(result)) {
         Events.publish("detected", result);
     }
 }

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -164,7 +164,7 @@ function transformResult(result) {
         yOffset = topRight.y,
         i;
 
-    if (!result || (xOffset === 0 && yOffset === 0)) {
+    if (xOffset === 0 && yOffset === 0) {
         return;
     }
 
@@ -204,7 +204,7 @@ function transformResult(result) {
 function addResult (result, imageData) {
     var i;
 
-    if (!imageData || !result || !_resultCollector) {
+    if (!imageData || !_resultCollector) {
         return;
     }
 
@@ -221,7 +221,7 @@ function addResult (result, imageData) {
 }
 
 function publishResult(result, imageData) {
-    if (_onUIThread) {
+    if (result && _onUIThread) {
         transformResult(result);
         addResult(result, imageData);
     }

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -178,6 +178,10 @@ function transformResult(result) {
         moveLine(result.line);
     }
 
+    if (result.box) {
+        moveBox(result.box);
+    }
+
     if (result.boxes && result.boxes.length > 0) {
         for (i = 0; i < result.boxes.length; i++) {
             moveBox(result.boxes[i]);
@@ -202,39 +206,35 @@ function transformResult(result) {
 }
 
 function addResult (result, imageData) {
-    var i;
-
     if (!imageData || !_resultCollector) {
         return;
     }
 
     if (result.barcodes) {
-        for (i = 0; i < result.barcodes.length; i++) {
-            addResult(result.barcodes[i], imageData);
-        }
-        return;
-    }
-
-    if (result.codeResult) {
+        result.barcodes.filter(barcode => barcode.codeResult)
+            .forEach(barcode => addResult(barcode, imageData));
+    } else if (result.codeResult) {
         _resultCollector.addResult(imageData, _inputStream.getCanvasSize(), result.codeResult);
     }
 }
 
 function hasCodeResult (result) {
-    return result && result.barcodes ?
+    return result && (result.barcodes ?
       result.barcodes.some(barcode => barcode.codeResult) :
-      result.codeResult;
+      result.codeResult);
 }
 
 function publishResult(result, imageData) {
+    const resultToPublish = result && (result.barcodes || result);
+
     if (result && _onUIThread) {
         transformResult(result);
         addResult(result, imageData);
     }
 
-    Events.publish("processed", result);
+    Events.publish("processed", resultToPublish);
     if (hasCodeResult(result)) {
-        Events.publish("detected", result);
+        Events.publish("detected", resultToPublish);
     }
 }
 


### PR DESCRIPTION
I have added an additional configuration to the `decoder` section called `multiple`.  If it is set to true, the decoder will not return after the first valid result.  The result object that gets emitted is slightly different for the end user since it has multiple barcodes on it.