### PR TITLE
Camera selection

### DIFF
--- a/src/input/camera_access.js
+++ b/src/input/camera_access.js
@@ -84,11 +84,19 @@ function normalizeConstraints(config, cb) {
 
     if ( typeof MediaStreamTrack !== 'undefined' && typeof MediaStreamTrack.getSources !== 'undefined') {
         MediaStreamTrack.getSources(function(sourceInfos) {
-            var videoSourceId;
+            var videoSourceId, facingDetected, videoIndex = 0;
             for (var i = 0; i < sourceInfos.length; ++i) {
                 var sourceInfo = sourceInfos[i];
-                if (sourceInfo.kind === "video" && sourceInfo.facing === videoConstraints.facing) {
-                    videoSourceId = sourceInfo.id;
+                if (sourceInfo.kind === "video" && !facingDetected) {
+                    if (sourceInfo.facing === videoConstraints.facing) {
+                        facingDetected = true;
+                    }
+                    
+                    if (!config.cameraIndex || config.cameraIndex <= videoIndex) {
+                        videoSourceId = sourceInfo.id;
+                    }
+                    
+                    videoIndex++;
                 }
             }
             constraints.video = {

--- a/src/input/camera_access.js
+++ b/src/input/camera_access.js
@@ -84,15 +84,16 @@ function normalizeConstraints(config, cb) {
 
     if ( typeof MediaStreamTrack !== 'undefined' && typeof MediaStreamTrack.getSources !== 'undefined') {
         MediaStreamTrack.getSources(function(sourceInfos) {
-            var videoSourceId, facingDetected, videoIndex = 0;
+            var videoSourceId, videoIndex = 0;
             for (var i = 0; i < sourceInfos.length; ++i) {
                 var sourceInfo = sourceInfos[i];
-                if (sourceInfo.kind === "video" && !facingDetected) {
+                if (sourceInfo.kind === "video") {
                     if (sourceInfo.facing === videoConstraints.facing) {
-                        facingDetected = true;
+                        videoSourceId = sourceInfo.id;
+                        break;
                     }
                     
-                    if (!config.cameraIndex || config.cameraIndex <= videoIndex) {
+                    if (videoConstraints.cameraIndex === 'undefined' || videoConstraints.cameraIndex >= videoIndex) {
                         videoSourceId = sourceInfo.id;
                     }
                     


### PR DESCRIPTION
Browsers like Chrome on Desktop/Android don't expose the `sourceInfo.facing` property, thus setting the `facing` config value of Quagga to `"environment"` or `"user"` doesn't work. Another way to select the camera is by index and this is implemented in the PR. Feel free to adapt/improve as you like, since it's a pretty simple solution.

Btw: sooner or later a switch should be done away from MediaStreamTrack: [https://www.chromestatus.com/feature/4765305641369600](https://www.chromestatus.com/feature/4765305641369600)... perhaps I'll fix it in an upcoming commit.