### PR TITLE
[Fix] Image area definition

### DIFF
--- a/src/common/cv_utils.js
+++ b/src/common/cv_utils.js
@@ -698,32 +698,32 @@ CVUtils.calculatePatchSize = function(patchSize, imgSize) {
 CVUtils._parseCSSDimensionValues = function(value) {
     var dimension = {
         value: parseFloat(value),
-        unit: value.indexOf("%") === value.length - 1 ? "%" : "%"
+        unit: value.indexOf("%") === value.length - 1 ? "%" : "px"
     };
 
     return dimension;
 };
 
 CVUtils._dimensionsConverters = {
-    top: function(dimension, context) {
-        if (dimension.unit === "%") {
-            return Math.floor(context.height * (dimension.value / 100));
-        }
+    top: function top(dimension, context) {
+        return Math.floor((dimension.unit === "%") 
+            ? (context.height * (dimension.value / 100))
+            : dimension.value);
     },
-    right: function(dimension, context) {
-        if (dimension.unit === "%") {
-            return Math.floor(context.width - (context.width * (dimension.value / 100)));
-        }
+    right: function right(dimension, context) {
+        return Math.floor((dimension.unit === "%")
+            ? (context.width - context.width * (dimension.value / 100))
+            : (context.width - dimension.value));
     },
-    bottom: function(dimension, context) {
-        if (dimension.unit === "%") {
-            return Math.floor(context.height - (context.height * (dimension.value / 100)));
-        }
+    bottom: function bottom(dimension, context) {
+        return Math.floor((dimension.unit === "%") 
+            ? (context.height - context.height * (dimension.value / 100))
+            : (context.height - dimension.value));
     },
-    left: function(dimension, context) {
-        if (dimension.unit === "%") {
-            return Math.floor(context.width * (dimension.value / 100));
-        }
+    left: function left(dimension, context) {
+        return Math.floor((dimension.unit === "%") 
+            ? (context.width * (dimension.value / 100))
+            : dimension.value);
     }
 };
 

--- a/src/quagga.js
+++ b/src/quagga.js
@@ -360,21 +360,23 @@ function workerInterface(factory) {
     var imageWrapper;
 
     self.onmessage = function(e) {
-        if (e.data.cmd === 'init') {
-            var config = e.data.config;
-            config.numOfWorkers = 0;
-            imageWrapper = new Quagga.ImageWrapper({
-                x: e.data.size.x,
-                y: e.data.size.y
-            }, new Uint8Array(e.data.imageData));
-            Quagga.init(config, ready, imageWrapper);
-            Quagga.onProcessed(onProcessed);
-        } else if (e.data.cmd === 'process') {
-            imageWrapper.data = new Uint8Array(e.data.imageData);
-            Quagga.start();
-        } else if (e.data.cmd === 'setReaders') {
-            Quagga.setReaders(e.data.readers);
-        }
+        setTimeout(function() {
+            if (e.data.cmd === 'init') {
+                var config = e.data.config;
+                config.numOfWorkers = 0;
+                imageWrapper = new Quagga.ImageWrapper({
+                    x: e.data.size.x,
+                    y: e.data.size.y
+                }, new Uint8Array(e.data.imageData));
+                Quagga.init(config, ready, imageWrapper);
+                Quagga.onProcessed(onProcessed);
+            } else if (e.data.cmd === 'process') {
+                imageWrapper.data = new Uint8Array(e.data.imageData);
+                Quagga.start();
+            } else if (e.data.cmd === 'setReaders') {
+                Quagga.setReaders(e.data.readers);
+            }
+        }, Quagga.getConfig().scanDelay || 0);
     };
 
     function onProcessed(result) {
@@ -516,5 +518,8 @@ export default {
     },
     ImageWrapper: ImageWrapper,
     ImageDebug: ImageDebug,
-    ResultCollector: ResultCollector
+    ResultCollector: ResultCollector,
+    getConfig: function getConfig() {
+        return _config;
+    }
 };


### PR DESCRIPTION
So far, the `inputStream.area` config definition allowed only `%` values, because `CVUtils._parseCSSDimensionValues` and `CVUtils._dimensionsConverters` only allowed percentages. I've fixed/adapted it to work with full (px) values as well.