### PR TITLE
Update readme to reflect `getUserMedia` support on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The above condition evaluates to:
 | Chrome        | `true`  |
 | Firefox       | `true`  |
 | IE 11         | `false` |
-| Safari iOS    | `true`  |
+| Safari iOS 11+| `true`  |
 | iOS WebView   | `false` |
 
 While `getUserMedia` is supported in Safari on iOS, it is disabled in any WebView

--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ The above condition evaluates to:
 | Chrome        | `true`  |
 | Firefox       | `true`  |
 | IE 11         | `false` |
-| Safari iOS    | `false` |
+| Safari iOS    | `true`  |
+| iOS WebView   | `false` |
+
+While `getUserMedia` is supported in Safari on iOS, it is disabled in any WebView
+(including UIWebView, WKWebView, and SFSafariViewController), as well as if the
+website has a `<meta name="apple-mobile-web-app-capable" content="yes">` tag and
+has been added to the homescreen. [More info here](https://stackoverflow.com/questions/46276130/ios11-getusermedia-with-apple-web-app-not-working/46717491?noredirect=1#comment80428262_46717491)
 
 ## <a name="installing">Installing</a>
 


### PR DESCRIPTION
Small README PR to update the support table to show that `getUserMedia` will work in some situations on iOS 11.