### PR TITLE
Reduce I2of5 false positives

### DIFF
--- a/src/reader/i2of5_reader.js
+++ b/src/reader/i2of5_reader.js
@@ -38,7 +38,7 @@ var N = 1,
             [N, W, N, W, N]
         ]},
         SINGLE_CODE_ERROR: {value: 0.78, writable: true},
-        AVG_CODE_ERROR: {value: 0.38, writable: true},
+        AVG_CODE_ERROR: {value: 0.25, writable: true},
         MAX_CORRECTION_FACTOR: {value: 5},
         FORMAT: {value: "i2of5"}
     };


### PR DESCRIPTION
I2of5 was giving me a TON of false positives on higher resolution cameras with the WebRTC scanning.

Reducing the AVG_CODE_ERROR down to .25 (from .38) greatly reduced these without impacting any other lower resolution camera devices I tested on.

