### PR TITLE
passing error back to decodeSingle through callbacks

### DIFF
--- a/lib/input_stream.js
+++ b/lib/input_stream.js
@@ -1,4 +1,4 @@
-const GetPixels = require("get-pixels");
+const getPixels = require("get-pixels");
 
 var InputStream = {};
 
@@ -22,12 +22,12 @@ InputStream.createImageStream = function() {
         _topRight = {x: 0, y: 0},
         _canvasSize = {x: 0, y: 0};
 
-    function loadImages() {
+    function loadImages(callback) {
         loaded = false;
-        GetPixels(baseUrl, _config.mime, function(err, pixels) {
+        getPixels(baseUrl, _config.mime, function (err, pixels) {
             if (err) {
                 console.log(err);
-                exit(1);
+                return callback(err);
             }
             loaded = true;
             console.log(pixels.shape);
@@ -84,11 +84,11 @@ InputStream.createImageStream = function() {
         return height;
     };
 
-    that.setInputStream = function(stream) {
+    that.setInputStream = function(stream, callback) {
         _config = stream;
         baseUrl = _config.src;
         size = 1;
-        loadImages();
+        loadImages(callback);
     };
 
     that.ended = function() {

--- a/lib/quagga.js
+++ b/lib/quagga.js
@@ -3645,7 +3645,11 @@ function initInputStream(cb) {
     }
 
     _inputStream.setAttribute("preload", "auto");
-    _inputStream.setInputStream(_config.inputStream);
+    _inputStream.setInputStream(_config.inputStream, function (err) {
+        if (err) {
+            cb(err);
+        }
+    });
     _inputStream.addEventListener("canrecord", canRecord.bind(undefined, cb));
 }
 
@@ -3838,6 +3842,10 @@ function locateAndDecode() {
 
 function update() {
     var availableWorker;
+
+    if (!_framegrabber) {
+      return;
+    }
 
     if (_onUIThread) {
         if (_workerPool.length > 0) {
@@ -4099,7 +4107,10 @@ exports.default = {
                 halfSample: false
             }
         }, config);
-        this.init(config, function () {
+        this.init(config, function (err) {
+            if (err) {
+                return resultCallback.call(null);
+            }
             _events2.default.once("processed", function (result) {
                 _this.stop();
                 resultCallback.call(null, result);
@@ -4219,7 +4230,7 @@ module.exports = FrameGrabber;
 "use strict";
 
 
-var GetPixels = __webpack_require__(164);
+var getPixels = __webpack_require__(164);
 
 var InputStream = {};
 
@@ -4243,13 +4254,13 @@ InputStream.createImageStream = function () {
         _topRight = { x: 0, y: 0 },
         _canvasSize = { x: 0, y: 0 };
 
-    function loadImages() {
+    function loadImages(callback) {
         loaded = false;
-        GetPixels(baseUrl, _config.mime, function (err, pixels) {
+        getPixels(baseUrl, _config.mime, function (err, pixels) {
             if (err) {
-                console.log(err);
-                exit(1);
+                return callback(err);
             }
+
             loaded = true;
             console.log(pixels.shape);
             frame = pixels;
@@ -4304,11 +4315,11 @@ InputStream.createImageStream = function () {
         return height;
     };
 
-    that.setInputStream = function (stream) {
+    that.setInputStream = function (stream, callback) {
         _config = stream;
         baseUrl = _config.src;
         size = 1;
-        loadImages();
+        loadImages(callback);
     };
 
     that.ended = function () {


### PR DESCRIPTION
I replaced the `exit(1);` call in `loadImages` inside of `InputStream.createImageStream` with a callback as a way to pass the error back to the caller. It has to be propagated back through the call stack in order for the caller to see it, so I've added callbacks through each layer or used existing callbacks to pass it along. It goes all the way back to the `Quagga.decodeSingle` call, which is what I'm focused on.

The error stops being propagated inside of `decodeSingle`, since that is a more public API that I'm not sure about changing now. The callback that's passed in normally accepts one argument, where the user would get a result back. If there is an error, the result will be `undefined`, since that is what I've seen when the code is not detected and a barcode is not located. Standard practice with [Error-first Callbacks](http://fredkschott.com/post/2014/03/understanding-error-first-callbacks-in-node-js/), though, would be to return the error as the first argument and give the result as the second. If we are willing to change the API for users, this is what I'd recommend.

I've written these changes mainly to the `lib/quagga.js` file, which is used when the project is imported as an NPM package. It looks like there is the same original duplicate code in a number of places, and I couldn't see if there was a single source of truth for code and a way to replicate it, so I made the changes that would get this working for me in Node. Please let me know if there is a proper way of defining these changes and replicating them where it is copied or generating them.

Fixes #359 